### PR TITLE
Allow running on PHP 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php": "^5.6",
+        "php": "^5.6 || ^7.0",
         "ext-mongo": "^1.5",
         "symfony/console": "^3.0"
     },


### PR DESCRIPTION
While there is no `ext-mongo` extension for PHP 7, this requirement can be filled using polyfills. This change allows people to run this library on PHP 7 using a different implementation for `ext-mongo`.
