### PR TITLE
Fixes in bin migrations

### DIFF
--- a/bin/migrations
+++ b/bin/migrations
@@ -5,7 +5,8 @@ $autoloadPaths = [
     __DIR__.'vendor/autoload.php',
     __DIR__.'/../autoload.php',
     __DIR__.'/../vendor/autoload.php',
-    __DIR__.'/../../autoload.php'
+    __DIR__.'/../../autoload.php',
+    __DIR__.'/../../../autoload.php',
 ];
 foreach ($autoloadPaths as $autoloadPath) {
     if (file_exists($autoloadPath)) {

--- a/bin/migrations
+++ b/bin/migrations
@@ -16,7 +16,7 @@ foreach ($autoloadPaths as $autoloadPath) {
 }
 
 if (!defined('COMPOSER_AUTOLOAD_PATH')) {
-    fwrite(STDERR, 'Could not find composer autoloader!');
+    fwrite(STDERR, 'Could not find composer autoloader!' . PHP_EOL);
     exit(1);
 }
 


### PR DESCRIPTION
Added new path for composer autoload search and line break to error message

Console command did not work for me (ubuntu 16.04, compover v1.4.1) because package was installed in `vendor/gruberro/php-mongo-migrations` and `autoload.php` could not be found in listed paths from `vendor/gruberro/php-mongo-migrations\bin` directory (symlink in `vendor/bin` did not change working directory). Added path that fixes problem
