### PR TITLE
 symfony/console 5.0 support 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ php:
   - 7.1
   - 7.2
   - 7.3
-  - 7.4snapshot
+  - 7.4
 
 services:
   - mongodb

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "php": "^7.0",
         "mongodb/mongodb": "^1.0.0",
-        "symfony/console": "^3.0|^4.0"
+        "symfony/console": "^3.0|^4.0|5.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7.27 || ^6.0 || ^7.0 || ^8.0"

--- a/lib/Console/Command/MigrationsCommand.php
+++ b/lib/Console/Command/MigrationsCommand.php
@@ -47,7 +47,7 @@ class MigrationsCommand extends AbstractCommand
     /**
      * {@inheritdoc}
      */
-    protected function execute(Console\Input\InputInterface $input, Console\Output\OutputInterface $output)
+    protected function execute(Console\Input\InputInterface $input, Console\Output\OutputInterface $output): int
     {
         $directories = $input->getArgument('migration-directories');
         $migrations = $this->getMigrations($directories);
@@ -126,5 +126,7 @@ class MigrationsCommand extends AbstractCommand
         } finally {
             $this->releaseLock($db);
         }
+
+        return 0;
     }
 }

--- a/lib/Console/Command/ReleaseLockCommand.php
+++ b/lib/Console/Command/ReleaseLockCommand.php
@@ -34,7 +34,7 @@ class ReleaseLockCommand extends Console\Command\Command
     /**
      * {@inheritdoc}
      */
-    protected function execute(Console\Input\InputInterface $input, Console\Output\OutputInterface $output)
+    protected function execute(Console\Input\InputInterface $input, Console\Output\OutputInterface $output): int
     {
         $client = new Client($input->getOption('server'));
         $db = $client->selectDatabase($input->getArgument('database'));
@@ -43,5 +43,7 @@ class ReleaseLockCommand extends Console\Command\Command
         $databaseMigrationsLockCollection = $db->selectCollection('DATABASE_MIGRATIONS_LOCK');
         $databaseMigrationsLockCollection->updateOne(['locked' => ['$exists' => true]], ['$set' => ['locked' => false]], ['upsert' => true]);
         $output->writeln("<info>✓ Successfully released migration lock</info>");
+
+        return 0;
     }
 }

--- a/lib/Console/Command/VersionsCommand.php
+++ b/lib/Console/Command/VersionsCommand.php
@@ -82,7 +82,7 @@ EOT
     /**
      * {@inheritdoc}
      */
-    protected function execute(Console\Input\InputInterface $input, Console\Output\OutputInterface $output)
+    protected function execute(Console\Input\InputInterface $input, Console\Output\OutputInterface $output): int
     {
         $id = $input->getOption('id');
         $directories = $input->getArgument('migration-directories');
@@ -133,6 +133,8 @@ EOT
         } finally {
             $this->releaseLock($db);
         }
+
+        return 0;
     }
 
     /**


### PR DESCRIPTION
Hopefully adding return typehints is ok too, it makes library more future compatible as consumers need to add return typehints first, only then can symfony do it.